### PR TITLE
Documentation update for WCT, DPT & CSTA scripts

### DIFF
--- a/py-json/LANforge/LFUtils.py
+++ b/py-json/LANforge/LFUtils.py
@@ -821,7 +821,6 @@ def wait_until_ports_disappear(base_url="http://localhost:8080", port_list=(), d
             url, resource_id, ",".join(temp_names_by_resource[resource_id]))
     if debug:
         logger.debug(pprint.pformat(("temp_query_by_resource", temp_query_by_resource)))
-    sec_elapsed = 0
     rm_ports_iteration = math.ceil(timeout_sec / 4)
     if rm_ports_iteration > 30:
         rm_ports_iteration = 30
@@ -829,7 +828,7 @@ def wait_until_ports_disappear(base_url="http://localhost:8080", port_list=(), d
         rm_ports_iteration = 1
 
     found_stations = []
-    for _ in range(0, timeout_sec):
+    for sec_elapsed in range(0, timeout_sec):
         found_stations = []
         for (resource, check_url) in temp_query_by_resource.items():
             if debug:

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -708,10 +708,11 @@ class LFCliBase:
             parser = argparse.ArgumentParser()
         optional = parser.add_argument_group('arguments with PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in /lanforge-scripts/py-json/LANforge/lfcli_base.py')
         required = parser.add_argument_group('arguments with NO PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in  /lanforge-scripts/py-json/LANforge/lfcli_base.py')
-        optional.add_argument('--mgr',
+        optional.add_argument('--mgr', "--m", "lanforge_ip", dest="mgr",
                               default='localhost',
                               help='hostname for where LANforge GUI is running')
-        optional.add_argument('--mgr_port',
+        optional.add_argument('--mgr_port', '--port', '--o', '--lanforge_port',
+                              dest='port',
                               default=8080,
                               help='port LANforge GUI HTTP service is running on')
         optional.add_argument('--debug',
@@ -757,14 +758,22 @@ class LFCliBase:
         # Optional Args
         optional.add_argument('--mgr',
                               '--lfmgr',
+                              '--m',
+                              '--lanforge_ip',
+                                dest='mgr',
                               default='localhost',
                               help='Hostname or IP address of the LANforge GUI machine (localhost is default)')
         optional.add_argument('--mgr_port',
                               '--port',
+                              '--o',
+                              '--lanforge_port',
+                              dest='port',
                               default=8080,
                               help='IP Port the LANforge GUI is listening on (8080 is default)')
         optional.add_argument('-u',
                               '--upstream_port',
+                              '--upstream',
+                              dest='upstream',
                               default='1.eth1',
                               help='non-station port that generates traffic: <resource>.<port>, e.g: 1.eth1')
         optional.add_argument('--num_stations',
@@ -774,14 +783,15 @@ class LFCliBase:
         optional.add_argument('--test_id',
                               default="webconsole",
                               help='Test ID (intended to use for ws events)')
-        optional.add_argument('-d',
-                              '--debug',
+        optional.add_argument('--debug',
                               action="store_true",
                               help='Enable debugging')
         optional.add_argument('--log_level',
+                              dest="log_level",
                               default=None,
                               help='Set logging level: debug | info | warning | error | critical')
         optional.add_argument('--lf_logger_config_json',
+                              dest="lf_logger_config_json",
                               help="--lf_logger_config_json <json file> , json configuration of logger")
         optional.add_argument('--proxy',
                               nargs='?',
@@ -816,17 +826,19 @@ class LFCliBase:
                     optional.add_argument(argument['name'], help=argument['help'])
 
         # Required Args
-        required.add_argument('--radio',
-                              help='radio EID, e.g: 1.wiphy2')
+        required.add_argument('--radio', default='wiphy0',
+                              help='create stations in lanforge at this radio (by default: wiphy0)')
         # Silently support capitalized security types
         required.add_argument('--security',
                               default="open",
                               help='WiFi Security protocol: < open | wep | wpa | wpa2 | wpa3 >')
         required.add_argument('--ssid',
                               help='WiFi SSID for script objects to associate to')
-        required.add_argument('--passwd',
+        required.add_argument('--paswd',
+                              '--passwd',
                               '--password',
                               '--key',
+                              dest='paswd',
                               default="[BLANK]",
                               help='WiFi passphrase/password/key')
         # please override this password argument using set_defaults(passwd='NA')

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -710,11 +710,11 @@ class LFCliBase:
         required = parser.add_argument_group('arguments with NO PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in  /lanforge-scripts/py-json/LANforge/lfcli_base.py')
         optional.add_argument('--mgr', "--m", "lanforge_ip", dest="mgr",
                               default='localhost',
-                              help='hostname for where LANforge GUI is running')
+                              help='Hostname or IP address of the LANforge GUI machine (localhost is default, use when running script on lanforge)')
         optional.add_argument('--mgr_port', '--port', '--o', '--lanforge_port',
                               dest='port',
                               default=8080,
-                              help='port LANforge GUI HTTP service is running on')
+                              help='IP Port the LANforge GUI is listening on (8080 is default)')
         optional.add_argument('--debug',
                               '-d',
                               default=False,
@@ -825,6 +825,7 @@ class LFCliBase:
 
         # Required Args
         required.add_argument('--radio',
+                              default='wiphy0',
                               help='create stations in lanforge at this radio (by default: wiphy0)')
         # Silently support capitalized security types
         required.add_argument('--security',

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -758,14 +758,12 @@ class LFCliBase:
         # Optional Args
         optional.add_argument('--mgr',
                               '--lfmgr',
-                              '--m',
                               '--lanforge_ip',
                                 dest='mgr',
                               default='localhost',
                               help='Hostname or IP address of the LANforge GUI machine (localhost is default)')
         optional.add_argument('--mgr_port',
                               '--port',
-                              '--o',
                               '--lanforge_port',
                               dest='port',
                               default=8080,
@@ -816,6 +814,19 @@ class LFCliBase:
                               default=None,
                               action="store_true",
                               help='Show summary of what this script does')
+        optional.add_argument('--radio',
+                              default='wiphy0',
+                              help='create stations in lanforge at this radio (by default: wiphy0)')
+        optional.add_argument('--security',
+                              default="open",
+                              help='WiFi Security protocol: < open | wep | wpa | wpa2 | wpa3 >')
+        optional.add_argument('--paswd',
+                              '--passwd',
+                              '--password',
+                              '--key',
+                              dest='paswd',
+                              default="[BLANK]",
+                              help='WiFi passphrase/password/key')
         if more_optional is not None:
             for argument in more_optional:
                 if 'default' in argument.keys():
@@ -823,23 +834,10 @@ class LFCliBase:
                 else:
                     optional.add_argument(argument['name'], help=argument['help'])
 
-        # Required Args
-        required.add_argument('--radio',
-                              default='wiphy0',
-                              help='create stations in lanforge at this radio (by default: wiphy0)')
+        # Required Args        
         # Silently support capitalized security types
-        required.add_argument('--security',
-                              default="open",
-                              help='WiFi Security protocol: < open | wep | wpa | wpa2 | wpa3 >')
         required.add_argument('--ssid',
                               help='WiFi SSID for script objects to associate to')
-        required.add_argument('--paswd',
-                              '--passwd',
-                              '--password',
-                              '--key',
-                              dest='paswd',
-                              default="[BLANK]",
-                              help='WiFi passphrase/password/key')
         # please override this password argument using set_defaults(passwd='NA')
 
         if more_required is not None:

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -826,7 +826,7 @@ class LFCliBase:
                     optional.add_argument(argument['name'], help=argument['help'])
 
         # Required Args
-        required.add_argument('--radio', default='wiphy0',
+        required.add_argument('--radio',
                               help='create stations in lanforge at this radio (by default: wiphy0)')
         # Silently support capitalized security types
         required.add_argument('--security',

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -787,11 +787,9 @@ class LFCliBase:
                               action="store_true",
                               help='Enable debugging')
         optional.add_argument('--log_level',
-                              dest="log_level",
                               default=None,
                               help='Set logging level: debug | info | warning | error | critical')
         optional.add_argument('--lf_logger_config_json',
-                              dest="lf_logger_config_json",
                               help="--lf_logger_config_json <json file> , json configuration of logger")
         optional.add_argument('--proxy',
                               nargs='?',

--- a/py-json/LANforge/lfcli_base.py
+++ b/py-json/LANforge/lfcli_base.py
@@ -708,7 +708,7 @@ class LFCliBase:
             parser = argparse.ArgumentParser()
         optional = parser.add_argument_group('arguments with PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in /lanforge-scripts/py-json/LANforge/lfcli_base.py')
         required = parser.add_argument_group('arguments with NO PRE-DEFINED DEFAULTS, arguments & defaults defined by create_bare_argparse found in  /lanforge-scripts/py-json/LANforge/lfcli_base.py')
-        optional.add_argument('--mgr', "--m", "lanforge_ip", dest="mgr",
+        optional.add_argument('--mgr', "--m", "--lfmgr", "lanforge_ip", dest="mgr",
                               default='localhost',
                               help='Hostname or IP address of the LANforge GUI machine (localhost is default, use when running script on lanforge)')
         optional.add_argument('--mgr_port', '--port', '--o', '--lanforge_port',
@@ -759,7 +759,7 @@ class LFCliBase:
         optional.add_argument('--mgr',
                               '--lfmgr',
                               '--lanforge_ip',
-                                dest='mgr',
+                              dest='mgr',
                               default='localhost',
                               help='Hostname or IP address of the LANforge GUI machine (localhost is default)')
         optional.add_argument('--mgr_port',
@@ -773,7 +773,11 @@ class LFCliBase:
                               '--upstream',
                               dest='upstream',
                               default='1.eth1',
-                              help='non-station port that generates traffic: <resource>.<port>, e.g: 1.eth1')
+                              help="""Upstream port used in test. Example: '1.1.eth2. This is the port of the A.P.
+                            that is connected to the LANforge system.  Default is eth1. All data being transmitted
+                            is done via this port.  This port is used to send and receive data
+                            to/from the A.P. that is being tested.
+                            format: <resource><port>""")
         optional.add_argument('--num_stations',
                               type=int,
                               default=0,

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -33,12 +33,12 @@ def cv_base_adjust_parser(args):
 
 def cv_add_base_parser(parser):
     """Update provided argparse argument parser with Chamber View-specific arguments."""
-    parser.add_argument("-m", "--mgr",
+    parser.add_argument("-m", "--mgr", "--lfmgr", "--lanforge_ip",
                         dest="mgr",
                         type=str,
                         default="localhost",
                         help="Hostname or IP address of the LANforge GUI machine (localhost is default)")
-    parser.add_argument("-o", "--port",
+    parser.add_argument("-o", "--port", "--mgr_port", "--lanforge_port",
                         dest="port",
                         type=int,
                         default=8080,

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -37,7 +37,7 @@ def cv_add_base_parser(parser):
                         dest="mgr",
                         type=str,
                         default="localhost",
-                        help="Hostname or IP address of the LANforge GUI machine (localhost is default)")
+                        help="Hostname or IP address of the LANforge GUI machine (localhost is default, use when running script on lanforge)")
     parser.add_argument("-o", "--port", "--mgr_port", "--lanforge_port",
                         dest="port",
                         type=int,
@@ -69,8 +69,9 @@ def cv_add_base_parser(parser):
 
     parser.add_argument("-r", "--pull_report",
                         dest="pull_report",
+                        default=False,
                         action='store_true',
-                        help="Pull reports from LANforge system. Off by default")
+                        help="Pull reports from LANforge system into the current system. Off by default")
     parser.add_argument("--load_old_cfg",
                         action='store_true',
                         help="Load defaults from previous run of the test")
@@ -123,6 +124,7 @@ def cv_add_base_parser(parser):
 
     parser.add_argument("-f", "--force",
                         dest="force",
+                        default=False,
                         action="store_true",
                         help="Force removal of any conflicting test instances. "
                              "Exercise caution with this option, as it will ungracefully stop "

--- a/py-json/cv_test_manager.py
+++ b/py-json/cv_test_manager.py
@@ -71,7 +71,8 @@ def cv_add_base_parser(parser):
                         dest="pull_report",
                         default=False,
                         action='store_true',
-                        help="Pull reports from LANforge system into the current system. Off by default")
+                        help="Pull reports from LANforge system into the current system. Off by default.\n"
+                            "Can use --local_lf_report_dir to specify where these reports are stored. By default reports are stored in same dir as the script.")
     parser.add_argument("--load_old_cfg",
                         action='store_true',
                         help="Load defaults from previous run of the test")
@@ -552,13 +553,11 @@ class cv_test(Realm):
         kpi_csv_data_present = False
         kpi_csv = ''
 
-        if self.local_lf_report_dir is None or self.local_lf_report_dir == "":
-            logger.info("Local report directory not specified. No KPI results present.")
-            return False
-        else:
-            kpi_location = self.local_lf_report_dir + "/" + os.path.basename(self.lf_report_dir)
-            # the lf_report_dir is the parent directory,  need to get the directory name
-            kpi_csv = "{kpi_location}/kpi.csv".format(kpi_location=kpi_location)
+        if self.pull_report and (self.local_lf_report_dir is None or self.local_lf_report_dir == ""):
+            self.local_lf_report_dir = os.getcwd()
+        kpi_location = self.local_lf_report_dir + "/" + os.path.basename(self.lf_report_dir)
+        # the lf_report_dir is the parent directory,  need to get the directory name
+        kpi_csv = "{kpi_location}/kpi.csv".format(kpi_location=kpi_location)
 
         if os.path.isfile(kpi_csv):
             kpi_size = os.path.getsize(kpi_csv)

--- a/py-scripts/create_station.py
+++ b/py-scripts/create_station.py
@@ -1076,7 +1076,7 @@ def main():
     create_station = CreateStation(**vars(args),
                                    sta_list=station_list,
                                    up=(not args.create_admin_down),
-                                   password=args.passwd,
+                                   password=args.paswd,
                                    set_txo_data=None)
 
     if not args.no_pre_cleanup:

--- a/py-scripts/create_station.py
+++ b/py-scripts/create_station.py
@@ -111,7 +111,7 @@ EXAMPLE:    # Create a single station
                 --passwd    <password> \
                 --security  wpa2 \
                 --num_stations 10 \
-                --initial_band_pref 5G
+                --initial_band_pref 5GHz
 
             # Create multiple stations
             ./create_station.py \
@@ -336,7 +336,7 @@ class CreateStation(Realm):
 
     def __init__(self,
                  mgr,
-                 mgr_port,
+                 port,
                  proxy,
                  debug,
                  up,
@@ -366,9 +366,9 @@ class CreateStation(Realm):
                  initial_band_pref,
                  **kwargs):
         super().__init__(mgr,
-                         mgr_port)
+                         port)
         self.host = mgr
-        self.port = mgr_port
+        self.port = port
         self.debug = debug
         self.up = up
         self.ssid = ssid

--- a/py-scripts/create_station.py
+++ b/py-scripts/create_station.py
@@ -855,7 +855,8 @@ INCLUDE_IN_README:
 """)
     parser.add_argument('--start_id',
                         type=int,
-                        help='Specify the station starting id \n e.g: --start_id <value> default 0',
+                        help='Specify the station starting id \n e.g: --start_id <value> default 0.\n'
+                        'All stations being created from --create_stations are named from this id, eg. sta<start_id>, sta<start_id + 1> ...',
                         default=0)
     parser.add_argument("--prefix",
                         type=str,
@@ -906,10 +907,11 @@ INCLUDE_IN_README:
                         default='AUTO')
     parser.add_argument("--country_code",
                         help='Radio Country Code:\n'
-                             'e.g: \t--country_code 840')
+                             'e.g: \t--country_code 840\n'
+                             'Could either mention the code, or the country itself')
     parser.add_argument("--eap_method",
                         type=str,
-                        help='Enter EAP method e.g: TLS')
+                        help='Enter EAP method e.g: TLS. If specified, also mention --eap_identitiy, --key_mgmt')
     parser.add_argument("--eap_identity",
                         "--radius_identity",
                         dest="eap_identity",
@@ -923,7 +925,7 @@ INCLUDE_IN_README:
                         "--radius_passwd",
                         dest="eap_password",
                         type=str,
-                        help="This is synonymous with the RADIUS user's password.")
+                        help="This is synonymous with the RADIUS user's password. Need to be specified when --eap_method is not TLS.",)
     parser.add_argument("--eap_phase1",
                         type=str,
                         help="EAP Phase 1 (outer authentication, i.e. TLS tunnel) parameters.\n"
@@ -937,13 +939,13 @@ INCLUDE_IN_README:
                         default="[BLANK]")  # TODO: Fix root cause of 'null' when not set issue (REST server-side issue)
     parser.add_argument("--pk_passwd",
                         type=str,
-                        help='Enter the private key password')
+                        help='Enter the private key password. Need to be mentioned when --eap_method is TLS')
     parser.add_argument("--ca_cert",
                         type=str,
-                        help='Enter path for certificate e.g: /home/lanforge/ca.pem')
+                        help='Enter path for certificate e.g: /home/lanforge/ca.pem. Need to be mentioned when --eap_method is TLS')
     parser.add_argument("--private_key",
                         type=str,
-                        help='Enter private key path e.g: /home/lanforge/client.p12')
+                        help='Enter private key path e.g: /home/lanforge/client.p12. Need to be mentioned when --eap_method is TLS')
     parser.add_argument("--key_mgmt",
                         type=str,
                         help="Authentication key management. Combinations are supported.\n")
@@ -957,7 +959,8 @@ INCLUDE_IN_README:
                              'CCMP-256\n'
                              'GCMP\n'
                              'GCMP-256\n'
-                             'CCMP/GCMP-256',
+                             'CCMP/GCMP-256\n'
+                             'Need to be specified when security is WPA3',
                              default='[BLANK]')
     parser.add_argument("--groupwise_cipher",
                         help='Groupwise Ciphers\n'
@@ -970,7 +973,8 @@ INCLUDE_IN_README:
                              'GCMP-256\n'
                              'CCMP-256\n'
                              'GCMP/CCMP-256\n'
-                             'ALL',
+                             'ALL\n'
+                             'Need to be specified when security is WPA3',
                         default='[BLANK]')
     parser.add_argument("--no_pre_cleanup",
                         help='Add this flag to stop cleaning up before station creation',

--- a/py-scripts/create_station.py
+++ b/py-scripts/create_station.py
@@ -887,7 +887,6 @@ INCLUDE_IN_README:
                         default="xx:xx:xx:*:*:xx")
     parser.add_argument("--radio_antenna",
                         help='Number of spatial streams: \n'
-                        ' default = -1 \n'
                         ' 0 Diversity (All) \n'
                         ' 1 Fixed-A (1x1) \n'
                         ' 4 AB (2x2) \n'

--- a/py-scripts/lf_dataplane_test.py
+++ b/py-scripts/lf_dataplane_test.py
@@ -22,7 +22,7 @@ NOTES:      To best understand the Dataplane test, please review manual configur
 EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated theoretical rate for one minute
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations           1.1.wlan0 \
                 --duration          1m \
                 --traffic_type      UDP \
                 --traffic_direction DUT-TX \
@@ -31,7 +31,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Run DUT receive test. Configure TCP traffic at 1 Gbps
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations           1.1.wlan0 \
                 --traffic_type      TCP \
                 --traffic_direction DUT-RX \
                 --rate              1Gbps
@@ -39,7 +39,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Run DUT transmit and receive test with multiple 250Mbps traffic configurations
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations           1.1.wlan0 \
                 --traffic_type      UDP,TCP \
                 --traffic_direction DUT-TX,DUT-RX \
                 --rate              250Mbps
@@ -48,7 +48,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Note that radio must support specified parameters. Recommended to first configure manually
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --traffic_type      UDP \
                 --rate              100Mbps \
                 --nss               1,2,3,4 \
@@ -58,7 +58,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # The values specified are *parsed as dB*
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --rate              100Mbps \
                 --attenuator1       "1.1.3273" \
                 --atten1_min        10 \
@@ -70,7 +70,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Ensure attenuation values are separated by two periods, otherwise test will not parse properly
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --rate              100Mbps \
                 --attenuator1       "1.1.3273" \
                 --attenuations1     "0..+100..955" \
@@ -82,7 +82,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
 
             {
                 "upstream": "1.1.eth1",
-                "station": "1.1.wlan0",
+                "stations": "1.1.wlan0",
                 "rate": "1Gbps"
             }
 
@@ -240,7 +240,7 @@ class DataplaneTest(cv_test):
         self.test_name = "Dataplane"
 
         self.upstream = upstream
-        self.station = station
+        self.stations = station
         self.dut = dut
         self.opposite_speed = opposite_speed
         self.speed = speed
@@ -370,8 +370,8 @@ class DataplaneTest(cv_test):
         # General test configuration
         if self.upstream != "":
             cfg_options.append("upstream_port: " + self.upstream)
-        if self.station != "":
-            cfg_options.append("traffic_port: " + self.station)
+        if self.stations != "":
+            cfg_options.append("traffic_port: " + self.stations)
         if self.duration != "":
             cfg_options.append("duration: " + self.duration)
 
@@ -470,7 +470,7 @@ NOTES:      To best understand the Dataplane test, please review manual configur
 EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated theoretical rate for one minute
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --duration          1m \
                 --traffic_type      UDP \
                 --traffic_direction DUT-TX \
@@ -479,7 +479,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Run DUT receive test. Configure TCP traffic at 1 Gbps
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --traffic_type      TCP \
                 --traffic_direction DUT-RX \
                 --rate              1Gbps
@@ -487,7 +487,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Run DUT transmit and receive test with multiple 250Mbps traffic configurations
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --traffic_type      UDP,TCP \
                 --traffic_direction DUT-TX,DUT-RX \
                 --rate              250Mbps
@@ -496,7 +496,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Note that radio must support specified parameters. Recommended to first configure manually
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --traffic_type      UDP \
                 --rate              100Mbps \
                 --nss               1,2,3,4 \
@@ -506,7 +506,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
             # Ensure attenuation values are separated by two periods, otherwise test will not parse properly
             ./lf_dataplane_test.py \
                 --upstream          1.1.eth1 \
-                --station           1.1.wlan0 \
+                --stations          1.1.wlan0 \
                 --rate              100Mbps \
                 --attenuator1       "1.1.3273" \
                 --attenuations1     "0..+100..955" \
@@ -518,7 +518,7 @@ EXAMPLE:    # Run DUT transmit test. Configure UDP traffic at 70% calculated the
 
             {
                 "upstream": "1.1.eth1",
-                "station": "1.1.wlan0",
+                "stations": "1.1.wlan0",
                 "rate": "1Gbps"
             }
 
@@ -544,12 +544,13 @@ INCLUDE_IN_README:
                         help="Path to JSON configuration file for test. When specified, JSON takes precedence over command line args.",
                         default="")
 
-    parser.add_argument("-u", "--upstream",
+    parser.add_argument("-u", "--upstream", "--upstream_port",
                         dest="upstream",
                         type=str,
                         default="",
                         help="Upstream port used in test. Example: '1.1.eth2'")
-    parser.add_argument("--station",
+    parser.add_argument("--s", "--station", "--stations",
+                        dest="stations",
                         type=str,
                         default="",
                         help="Station used in test. Example: '1.1.sta01500'")
@@ -597,7 +598,8 @@ INCLUDE_IN_README:
                         type=str,
                         help="Direction(s) of generated traffic, relative to DUT. Bi-directional traffic may be "
                              "achieved by setting the opposite.")
-    parser.add_argument("--type",
+    parser.add_argument("--protocol",
+                        "--type",
                         "--types",
                         "--traffic_type",
                         "--traffic_types",
@@ -610,17 +612,15 @@ INCLUDE_IN_README:
                         "--download_speed",
                         "--download_rate",
                         dest="speed",
-                        default="",
-                        help="Requested traffic rate used in test for selected traffic direction(s). "
-                             "Percentage of theoretical is also supported. Default: 85%%.")
+                        default="1Gbps",
+                        help="Select requested download rate.  Kbps, Mbps, Gbps units supported.  Default is 1Gbps")
     parser.add_argument("--opposite_speed",
                         "--opposite_rate",
                         "--upload_speed",
                         "--upload_rate",
                         dest="opposite_speed",
-                        default="",
-                        help="Requested opposite traffic rate used in test for selected traffic direction(s). "
-                             "Percentage of theoretical is also supported. Default: 0")
+                        default="10Mbps",
+                        help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
 
     parser.add_argument("--duration",
                         default="",
@@ -706,7 +706,7 @@ INCLUDE_IN_README:
                             must also have --pull_report also set to pull reports""")
     # Logging configuration
     parser.add_argument("--lf_logger_config_json",
-                        help="Path to logger JSON configuration")
+                        help="--lf_logger_config_json <json file> : Path to logger JSON configuration of logger")
     parser.add_argument('--logger_no_file',
                         default=None,
                         action="store_true",
@@ -842,7 +842,7 @@ def apply_json_configuration(args):
     if "duration" in json_data:
         args.duration = json_data["duration"]
     if "station" in json_data:
-        args.station = json_data["station"]
+        args.stations = json_data["station"]
 
     # Traffic configuration
     for key in ["speed", "rate", "download_speed", "download_rate"]:

--- a/py-scripts/lf_dataplane_test.py
+++ b/py-scripts/lf_dataplane_test.py
@@ -612,15 +612,17 @@ INCLUDE_IN_README:
                         "--download_speed",
                         "--download_rate",
                         dest="speed",
-                        default="1Gbps",
-                        help="Select requested download rate.  Kbps, Mbps, Gbps units supported.  Default is 1Gbps")
+                        default="",
+                        help="Requested traffic rate used in test for selected traffic direction(s). "
+                             "Percentage of theoretical is also supported. Default: 85%%.")
     parser.add_argument("--opposite_speed",
                         "--opposite_rate",
                         "--upload_speed",
                         "--upload_rate",
                         dest="opposite_speed",
-                        default="10Mbps",
-                        help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
+                        default="",
+                        help="Requested opposite traffic rate used in test for selected traffic direction(s). "
+                             "Percentage of theoretical is also supported. Default: 0")
 
     parser.add_argument("--duration",
                         default="",

--- a/py-scripts/lf_dataplane_test.py
+++ b/py-scripts/lf_dataplane_test.py
@@ -190,7 +190,7 @@ class DataplaneTest(cv_test):
                  bandwidths=None,
                  channels=None,
                  traffic_directions=None,
-                 traffic_types=None,
+                 traffic_type=None,
                  opposite_speed="0",
                  speed="85%",
                  duration="15s",
@@ -256,7 +256,7 @@ class DataplaneTest(cv_test):
 
         # Traffic configuration
         self.traffic_directions = DataplaneTest._prepare_as_rawline(traffic_directions, self.TRAFFIC_DIRECTION_MAP)
-        self.traffic_types = DataplaneTest._prepare_as_rawline(traffic_types, self.TRAFFIC_TYPE_MAP)
+        self.traffic_type = DataplaneTest._prepare_as_rawline(traffic_type, self.TRAFFIC_TYPE_MAP)
 
         # Attenuator configuration
         self.attenuator = attenuator
@@ -386,8 +386,8 @@ class DataplaneTest(cv_test):
         # Traffic configuration
         if self.traffic_directions:
             cfg_options.append("directions: " + self.traffic_directions)
-        if self.traffic_types:
-            cfg_options.append("traffic_types: " + self.traffic_types)
+        if self.traffic_type:
+            cfg_options.append("traffic_type: " + self.traffic_type)
         if self.speed != "":
             cfg_options.append("speed: " + self.speed)
         if self.opposite_speed != "":
@@ -603,7 +603,7 @@ INCLUDE_IN_README:
                         "--types",
                         "--traffic_type",
                         "--traffic_types",
-                        dest="traffic_types",
+                        dest="traffic_type",
                         default=None,
                         type=str,
                         help="Type(s) of generated traffic")
@@ -749,8 +749,8 @@ def validate_args(args):
                 logger.error(f"Unexpected traffic direction {direction}, supported are: {DataplaneTest.TRAFFIC_DIRECTION_MAP.keys()}")
                 exit(1)
 
-    if args.traffic_types:
-        traffic_types = args.traffic_types.split(",")
+    if args.traffic_type:
+        traffic_types = args.traffic_type.split(",")
 
         for traffic_type in traffic_types:
             if traffic_type not in DataplaneTest.TRAFFIC_TYPE_MAP:
@@ -860,9 +860,9 @@ def apply_json_configuration(args):
         arg_value=args.traffic_directions,
         keys=["direction", "directions", "traffic_direction", "traffic_directions"]
     )
-    args.traffic_types = __apply_csv_json(
+    args.traffic_type = __apply_csv_json(
         json_data=json_data,
-        arg_value=args.traffic_types,
+        arg_value=args.traffic_type,
         keys=["type", "types", "traffic_type", "traffic_types"]
     )
 

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -25,6 +25,7 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
             # pre-existing and pre-configured stations 'sta0000' and 'sta0001'
             # together
                 ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.207.75 \
                     --pull_report   \
                     --upstream      1.1.eth1 \
                     --stations      1.1.sta0000,1.1.sta0001 \
@@ -38,6 +39,55 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                 ./lf_wifi_capacity_test.py \
                     --pull_report   \
                     --config_name   existing_wct_config
+
+            # Run test with creating stations in lanforge starting from given index with specified ssid and security type
+            # with 10 stations and 1.1.eth1 as upstream port
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.158.1.101\
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --create_stations \
+                    --radio         wiphy0 \
+                    --start_id      1000 \                          # starting index of station to be created
+                    --num_stations  10 \                            # create this number of stations starting from start_id
+                    --stations      1.1.sta1010,1.1.sta2020         # or create stations with these names if specified
+                    --ssid          test_ssid \
+                    --security      WPA2 \
+                    --paswd         test_password \
+
+            # Run test on multiple stations and obtain individual station upload and download rates
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101\
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001 \
+                    --per_station_upload_rate \
+                    --per_station_download_rate \
+
+
+            # Run test on multiple stations seperating into batches
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001,1.1.sta0002,1.1.sta0003,1.1.sta0004,1.1.sta0005
+                    --batch_size    2 \
+
+            # Run test and save the reports in a specific directory on the executing system
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101 \
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001 \
+                    --local_lf_report_dir /home/user/lf_reports \
+            #Run test with custom download / upload rates for each station
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101 \
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta000
+                    --download_rate 100Mbps \
+                    --upload_rate   1Mbps \
 
 SCRIPT_CLASSIFICATION:
             Test
@@ -139,7 +189,7 @@ class WiFiCapacityTest(cv_test):
         self.test_name = "WiFi Capacity"
         self.batch_size = batch_size
         self.loop_iter = loop_iter
-        self.protocol = protocol
+        self.traffic_types = protocol
         self.duration = duration
         self.upload_rate = upload_rate
         self.download_rate = download_rate
@@ -223,8 +273,8 @@ class WiFiCapacityTest(cv_test):
             cfg_options.append("batch_size: " + self.batch_size)
         if self.loop_iter != "":
             cfg_options.append("loop_iter: " + self.loop_iter)
-        if self.protocol != "":
-            cfg_options.append("protocol: " + str(self.protocol))
+        if self.traffic_types != "":
+            cfg_options.append("traffic_types: " + str(self.traffic_types))
         if self.duration != "":
             cfg_options.append("duration: " + self.duration)
         if self.upload_rate != "":
@@ -308,6 +358,7 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
             # pre-existing and pre-configured stations 'sta0000' and 'sta0001'
             # together
                 ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.207.75 \
                     --pull_report   \
                     --upstream      1.1.eth1 \
                     --stations      1.1.sta0000,1.1.sta0001 \
@@ -321,6 +372,56 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                 ./lf_wifi_capacity_test.py \
                     --pull_report   \
                     --config_name   existing_wct_config
+
+            # Run test with creating stations in lanforge starting from given index with specified ssid and security type
+            # with 10 stations and 1.1.eth1 as upstream port
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.158.1.101\
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --create_stations \
+                    --radio         wiphy0 \
+                    --start_id      1000 \                          # starting index of station to be created
+                    --num_stations  10 \                            # create this number of stations starting from start_id
+                    --stations      1.1.sta1010,1.1.sta2020         # or create stations with these names if specified
+                    --ssid          test_ssid \
+                    --security      WPA2 \
+                    --paswd         test_password \
+
+            # Run test on multiple stations and obtain individual station upload and download rates
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101\
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001 \
+                    --per_station_upload_rate \
+                    --per_station_download_rate \
+
+
+            # Run test on multiple stations seperating into batches
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001,1.1.sta0002,1.1.sta0003,1.1.sta0004,1.1.sta0005
+                    --batch_size    2 \
+
+            # Run test and save the reports in a specific directory on the executing system
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101 \
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta0001 \
+                    --local_lf_report_dir /home/user/lf_reports \
+            
+            #Run test with custom download / upload rates for each station
+                ./lf_wifi_capacity_test.py \
+                    --mgr           192.168.1.101 \
+                    --pull_report   \
+                    --upstream      1.1.eth1 \
+                    --stations      1.1.sta0000,1.1.sta000
+                    --download_rate 100Mbps \
+                    --upload_rate   1Mbps \
 
 SCRIPT_CLASSIFICATION:
             Test
@@ -339,41 +440,45 @@ INCLUDE_IN_README:
 
     cv_add_base_parser(parser)  # see cv_test_manager.py
 
-    parser.add_argument("-u", "--upstream", type=str, default="",
-                        help="Upstream port for wifi capacity test ex. 1.1.eth1")
+    parser.add_argument("-u", "--upstream", "--upstream_port", dest="upstream", type=str, default="",
+                        help="Upstream port used in test. Example: '1.1.eth2")
     parser.add_argument("-b", "--batch_size", type=str, default="",
-                        help="station increment ex. 1,2,3")
+                        help="Select number of stations to add per iteration.  Default is 1")
     parser.add_argument("-l", "--loop_iter", type=str, default="",
                         help="Loop iteration ex. 1")
-    parser.add_argument("-p", "--protocol", type=str, default="",
+    parser.add_argument("-p", "--protocol", "--type", "--types", "--traffic_type", "--traffic_types", type=str, dest="traffic_types", default="",
                         help="Protocol ex.TCP-IPv4")
     parser.add_argument("-d", "--duration", type=str, default="",
-                        help="duration in ms. ex. 5000")
-    parser.add_argument("--verbosity", default="5", help="Specify verbosity of the report values 1 - 11 default 5")
-    parser.add_argument("--download_rate", type=str, default="1Gbps",
+                        help="Duration of each traffic run")
+    parser.add_argument("--verbosity", default="5", help="Verbosity of the report specified as single value in 1 - 11 range (whole numbers).\n"
+                             "The larger the number, the more verbose. Default: 5")
+    parser.add_argument("--speed", "--rate", "--download_speed", "--download_rate", type=str, default="1Gbps",
                         help="Select requested download rate.  Kbps, Mbps, Gbps units supported.  Default is 1Gbps")
-    parser.add_argument("--upload_rate", type=str, default="10Mbps",
+    parser.add_argument("--opposite_speed", "--opposite_rate", "--upload_speed", "--upload_rate", type=str, default="10Mbps",
                         help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
     parser.add_argument("--sort", type=str, default="interleave",
                         help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.")
-    parser.add_argument("-s", "--stations", type=str, default="",
+    parser.add_argument("-s", "--station", "--stations", dest="stations", type=str, default="",
                         help="If specified, these stations will be used.  If not specified, all available stations will be selected.  Example: 1.1.sta001,1.1.wlan0,...")
     parser.add_argument("-cs", "--create_stations", default=False, action='store_true',
-                        help="create stations in lanforge (by default: False)")
+                        help="""create stations in lanforge (by default: False)
+                        If specifed, either mention --num_stations or --stations to create stations in lanforge. If both are specified, --stations will be used to create stations
+                        Also mention --radio, --ssid, --security and --password to create stations with these parameters""")
     parser.add_argument("-radio", "--radio", default="wiphy0",
                         help="create stations in lanforge at this radio (by default: wiphy0)")
     parser.add_argument("-ssid", "--ssid", default="",
                         help="ssid name")
     parser.add_argument("-security", "--security", default="open",
-                        help="ssid Security type")
-    parser.add_argument("-paswd", "--paswd", "-passwd", "--passwd", default="[BLANK]",
-                        help="ssid Password")
+                        help="ssid Security type. If not open, then mention --password to create stations with this security type and password")
+    parser.add_argument("-paswd", "--paswd", "-passwd", "--passwd", "--password", "--key", dest="paswd", default="[BLANK]",
+                        help="WiFi passphrase/password/key. Leave empty for open security type.")
     parser.add_argument("--report_dir", default="")
     parser.add_argument("--scenario", default="")
-    parser.add_argument("--graph_groups", help="File to save graph groups to", default=None)
-    parser.add_argument("--local_lf_report_dir", help="--local_lf_report_dir <where to pull reports to>  default '' put where dataplane script run from", default="")
-    parser.add_argument("--lf_logger_config_json", help="--lf_logger_config_json <json file> , json configuration of logger")
-    parser.add_argument("--num_stations", help="Specify the number of stations need to be create.", type=int,
+    parser.add_argument("--graph_groups", help="Path to file to save graph_groups to on local system", default=None)
+    parser.add_argument("--local_lf_report_dir", help="""--local_lf_report_dir <where to pull reports to>  default ''  means put in current working directory,
+                         must also have --pull_report also set to pull reports.""", default="")
+    parser.add_argument("--lf_logger_config_json", dest="lf_logger_config_json", help="--lf_logger_config_json <json file> : Path to logger JSON configuration of logger")
+    parser.add_argument("--num_stations", help="Specify the number of stations need to be create. Could use --start_id to specify the starting ID of the stations being used.", type=int,
                         default=None)
     parser.add_argument('--start_id', help='Specify the station starting id \n e.g: --start_id <value> default 0',
                         default=0)

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -48,9 +48,9 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                     --upstream      1.1.eth1 \
                     --create_stations \
                     --radio         wiphy0 \
-                    --start_id      1000 \                          # starting index of station to be created
-                    --num_stations  10 \                            # create this number of stations starting from start_id
-                    --stations      1.1.sta1010,1.1.sta2020         # or create stations with these names if specified
+                    --start_id      1000 \
+                    --num_stations  10 \
+                    --stations      1.1.sta1010,1.1.sta2020 \
                     --ssid          test_ssid \
                     --security      WPA2 \
                     --paswd         test_password \
@@ -390,16 +390,16 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                     --config_name   existing_wct_config
 
             # Run test with creating stations in lanforge starting from given index with specified ssid and security type
-            # with 10 stations and 1.1.eth1 as upstream port
+            # with 10 stations and 1.1.eth1 as upstream port, starting the id from a specifc value, (either create specific number of stations with this id, or create stations with given names)
                 ./lf_wifi_capacity_test.py \
                     --mgr           192.158.1.101\
                     --pull_report   \
                     --upstream      1.1.eth1 \
                     --create_stations \
                     --radio         wiphy0 \
-                    --start_id      1000 \                          # starting index of station to be created
-                    --num_stations  10 \                            # create this number of stations starting from start_id
-                    --stations      1.1.sta1010,1.1.sta2020         # or create stations with these names if specified
+                    --start_id      1000 \
+                    --num_stations  10 \         
+                    --stations      1.1.sta1010,1.1.sta2020
                     --ssid          test_ssid \
                     --security      WPA2 \
                     --paswd         test_password \
@@ -458,9 +458,10 @@ INCLUDE_IN_README:
 
     parser.add_argument("-u", "--upstream", "--upstream_port", dest="upstream", type=str, default="eth1",
                         help="""Upstream port used in test. Example: '1.1.eth2. This is the port of the A.P.
-                        that is connected to the LANforge system.  Default is eth1. All data being transmitted
-                        is done via this port.  This port is used to send and receive data
-                        to/from the A.P. that is being tested.""")
+                            that is connected to the LANforge system.  Default is eth1. All data being transmitted
+                            is done via this port.  This port is used to send and receive data
+                            to/from the A.P. that is being tested.
+                            format: <resource><port>""")
     parser.add_argument("-b", "--batch_size", type=str, default="1",
                         help="""Select number of stations to add per iteration.  Default is 1.
                         This is the number of stations that will be added to the test for each iteration.
@@ -482,7 +483,7 @@ INCLUDE_IN_README:
     parser.add_argument("--opposite_speed", "--opposite_rate", "--upload_speed", "--upload_rate", dest="upload_rate", type=str, default="10Mbps",
                         help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
     parser.add_argument("--sort", type=str, default="interleave",
-                        help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.") #enduku sort cheyali? enti use?
+                        help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.")
     parser.add_argument("-s", "--station", "--stations", dest="stations", type=str, default="",
                         help="If specified, these stations will be used.  If not specified, all available stations will be selected.  Example: 1.1.sta001,1.1.wlan0,....\n"
                             "Can also be used to specify custon names for the stations being created by --create_stations param\n"
@@ -492,7 +493,7 @@ INCLUDE_IN_README:
                         If specifed, either mention --num_stations or --stations to create stations in lanforge. If both are specified, --stations will be used to create stations
                         Also mention --radio, --ssid, --security and --password to create stations with these parameters""")
     parser.add_argument("-radio", "--radio", default="wiphy0",
-                        help="create stations in lanforge at this radio (by default: wiphy0)")    #only one radio? or multiple radios possible?
+                        help="create stations in lanforge at this radio (by default: wiphy0)")
     parser.add_argument("-ssid", "--ssid", default="",
                         help="ssid of the network to which stations should connect to. Required if --create_stations is specified")
     parser.add_argument("-security", "--security", default="open",

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -275,7 +275,7 @@ class WiFiCapacityTest(cv_test):
         if self.loop_iter != "":
             cfg_options.append("loop_iter: " + self.loop_iter)
         if self.traffic_type != "":
-            cfg_options.append("traffic_type: " + str(self.traffic_type))
+            cfg_options.append("protocol: " + str(self.traffic_type))
         if self.duration != "":
             cfg_options.append("duration: " + self.duration)
         if self.upload_rate != "":
@@ -471,9 +471,10 @@ INCLUDE_IN_README:
                         For example, if you have 10 stations and a loop iteration of 2, then the test
                         will run 2 times with all 10 stations being used for each iteration. Default is 1""")
     parser.add_argument("-p", "--protocol", "--type", "--types", "--traffic_type", "--traffic_types", type=str, dest="traffic_type", default="UDP-IPv4",
-                        help="Protocol ex.TCP-IPv4. <TCP, UDP, layer 4-7, TCP&UDP>  Default is UDP-IPv4. Only one protocol can be selected at a time.")
+                        help="Protocol ex.TCP-IPv4. Default is UDP-IPv4. Only one protocol can be selected at a time.\n"
+                            "UDP, TCP, layer4-7, TCP&UDP are avialable options")
     parser.add_argument("-d", "--duration", type=str, default="5000",
-                        help="Duration of each traffic run. Default is 5s. <s, m, h>  Example: 5s, 1m, 2h. Each station is tested for this duration.")
+                        help="Duration of each traffic run. Default is 5s. Example: 5s, 1m, 2h. Each station is tested for this duration.")
     parser.add_argument("--verbosity", default="5", help="Verbosity of the report specified as single value in 1 - 11 range (whole numbers).\n"
                              "The larger the number, the more verbose. Default: 5")
     parser.add_argument("--speed", "--rate", "--download_speed", "--download_rate", type=str, default="1Gbps",
@@ -484,7 +485,8 @@ INCLUDE_IN_README:
                         help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.") #enduku sort cheyali? enti use?
     parser.add_argument("-s", "--station", "--stations", dest="stations", type=str, default="",
                         help="If specified, these stations will be used.  If not specified, all available stations will be selected.  Example: 1.1.sta001,1.1.wlan0,....\n"
-                            "Can also be used to specify custon names for the stations being created by --create_stations param")
+                            "Can also be used to specify custon names for the stations being created by --create_stations param\n"
+                            "<shelf>.<resource>.<alias>")
     parser.add_argument("-cs", "--create_stations", default=False, action='store_true',
                         help="""create stations in lanforge (by default: False)
                         If specifed, either mention --num_stations or --stations to create stations in lanforge. If both are specified, --stations will be used to create stations

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -80,6 +80,7 @@ EXAMPLE:    # Run 60 second default DL/UL-rate UDP IPv4 traffic-based test with
                     --upstream      1.1.eth1 \
                     --stations      1.1.sta0000,1.1.sta0001 \
                     --local_lf_report_dir /home/user/lf_reports \
+                        
             #Run test with custom download / upload rates for each station
                 ./lf_wifi_capacity_test.py \
                     --mgr           192.168.1.101 \
@@ -477,7 +478,7 @@ INCLUDE_IN_README:
     parser.add_argument("--graph_groups", help="Path to file to save graph_groups to on local system", default=None)
     parser.add_argument("--local_lf_report_dir", help="""--local_lf_report_dir <where to pull reports to>  default ''  means put in current working directory,
                          must also have --pull_report also set to pull reports.""", default="")
-    parser.add_argument("--lf_logger_config_json", dest="lf_logger_config_json", help="--lf_logger_config_json <json file> : Path to logger JSON configuration of logger")
+    parser.add_argument("--lf_logger_config_json", help="--lf_logger_config_json <json file> : Path to logger JSON configuration of logger")
     parser.add_argument("--num_stations", help="Specify the number of stations need to be create. Could use --start_id to specify the starting ID of the stations being used.", type=int,
                         default=None)
     parser.add_argument('--start_id', help='Specify the station starting id \n e.g: --start_id <value> default 0',

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -455,7 +455,7 @@ INCLUDE_IN_README:
                              "The larger the number, the more verbose. Default: 5")
     parser.add_argument("--speed", "--rate", "--download_speed", "--download_rate", type=str, default="1Gbps",
                         help="Select requested download rate.  Kbps, Mbps, Gbps units supported.  Default is 1Gbps")
-    parser.add_argument("--opposite_speed", "--opposite_rate", "--upload_speed", "--upload_rate", type=str, default="10Mbps",
+    parser.add_argument("--opposite_speed", "--opposite_rate", "--upload_speed", "--upload_rate", dest="upload_rate", type=str, default="10Mbps",
                         help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
     parser.add_argument("--sort", type=str, default="interleave",
                         help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.")

--- a/py-scripts/lf_wifi_capacity_test.py
+++ b/py-scripts/lf_wifi_capacity_test.py
@@ -141,7 +141,7 @@ class WiFiCapacityTest(cv_test):
                  upstream="eth1",
                  batch_size="1",
                  loop_iter="1",
-                 protocol="UDP-IPv4",
+                 traffic_type="UDP-IPv4",
                  duration="5000",
                  pull_report=False,
                  load_old_cfg=False,
@@ -190,7 +190,7 @@ class WiFiCapacityTest(cv_test):
         self.test_name = "WiFi Capacity"
         self.batch_size = batch_size
         self.loop_iter = loop_iter
-        self.traffic_types = protocol
+        self.traffic_type = traffic_type
         self.duration = duration
         self.upload_rate = upload_rate
         self.download_rate = download_rate
@@ -274,8 +274,8 @@ class WiFiCapacityTest(cv_test):
             cfg_options.append("batch_size: " + self.batch_size)
         if self.loop_iter != "":
             cfg_options.append("loop_iter: " + self.loop_iter)
-        if self.traffic_types != "":
-            cfg_options.append("traffic_types: " + str(self.traffic_types))
+        if self.traffic_type != "":
+            cfg_options.append("traffic_type: " + str(self.traffic_type))
         if self.duration != "":
             cfg_options.append("duration: " + self.duration)
         if self.upload_rate != "":
@@ -316,6 +316,21 @@ class WiFiCapacityTest(cv_test):
 
         self.rm_text_blob(self.config_name, "Wifi-Capacity-")  # To delete old config with same name
 
+def validate_args(args):
+    if args.create_stations:
+        if not args.num_stations and not args.stations:
+            logger.error("Either mention names to stations to be created(--stations) or number of stations to be created(--num_stations). [Same precedence order]")
+        if not args.ssid:
+            logger.error("Requires ssid to create station, mention with --ssid")
+            exit(1)
+    if args.ssid:
+        if not args.security:
+            logger.error("Requires secuirty to connect to wifi, mention with --security")
+            exit(1)
+    if args.security.lower != 'open':
+        if not args.paswd:
+            logger.error("Requires password to connect to wifi whose security is not open, mention with --password")
+            exit(1)    
 
 def main():
     help_summary = "The Candela WiFi Capacity test is designed to measure performance of an " \
@@ -441,16 +456,24 @@ INCLUDE_IN_README:
 
     cv_add_base_parser(parser)  # see cv_test_manager.py
 
-    parser.add_argument("-u", "--upstream", "--upstream_port", dest="upstream", type=str, default="",
-                        help="Upstream port used in test. Example: '1.1.eth2")
-    parser.add_argument("-b", "--batch_size", type=str, default="",
-                        help="Select number of stations to add per iteration.  Default is 1")
-    parser.add_argument("-l", "--loop_iter", type=str, default="",
-                        help="Loop iteration ex. 1")
-    parser.add_argument("-p", "--protocol", "--type", "--types", "--traffic_type", "--traffic_types", type=str, dest="traffic_types", default="",
-                        help="Protocol ex.TCP-IPv4")
-    parser.add_argument("-d", "--duration", type=str, default="",
-                        help="Duration of each traffic run")
+    parser.add_argument("-u", "--upstream", "--upstream_port", dest="upstream", type=str, default="eth1",
+                        help="""Upstream port used in test. Example: '1.1.eth2. This is the port of the A.P.
+                        that is connected to the LANforge system.  Default is eth1. All data being transmitted
+                        is done via this port.  This port is used to send and receive data
+                        to/from the A.P. that is being tested.""")
+    parser.add_argument("-b", "--batch_size", type=str, default="1",
+                        help="""Select number of stations to add per iteration.  Default is 1.
+                        This is the number of stations that will be added to the test for each iteration.
+                        For example, if you have 10 stations and a batch size of 2, then the test will
+                        run 5 iterations with 2 stations being added for each iteration.""")
+    parser.add_argument("-l", "--loop_iter", type=str, default="1",
+                        help="""Loop iteration ex. 1. This is the number of times the test will be run.
+                        For example, if you have 10 stations and a loop iteration of 2, then the test
+                        will run 2 times with all 10 stations being used for each iteration. Default is 1""")
+    parser.add_argument("-p", "--protocol", "--type", "--types", "--traffic_type", "--traffic_types", type=str, dest="traffic_type", default="UDP-IPv4",
+                        help="Protocol ex.TCP-IPv4. <TCP, UDP, layer 4-7, TCP&UDP>  Default is UDP-IPv4. Only one protocol can be selected at a time.")
+    parser.add_argument("-d", "--duration", type=str, default="5000",
+                        help="Duration of each traffic run. Default is 5s. <s, m, h>  Example: 5s, 1m, 2h. Each station is tested for this duration.")
     parser.add_argument("--verbosity", default="5", help="Verbosity of the report specified as single value in 1 - 11 range (whole numbers).\n"
                              "The larger the number, the more verbose. Default: 5")
     parser.add_argument("--speed", "--rate", "--download_speed", "--download_rate", type=str, default="1Gbps",
@@ -458,17 +481,18 @@ INCLUDE_IN_README:
     parser.add_argument("--opposite_speed", "--opposite_rate", "--upload_speed", "--upload_rate", dest="upload_rate", type=str, default="10Mbps",
                         help="Select requested upload rate.  Kbps, Mbps, Gbps units supported.  Default is 10Mbps")
     parser.add_argument("--sort", type=str, default="interleave",
-                        help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.")
+                        help="Select station sorting behaviour:  none | interleave | linear  Default is interleave.") #enduku sort cheyali? enti use?
     parser.add_argument("-s", "--station", "--stations", dest="stations", type=str, default="",
-                        help="If specified, these stations will be used.  If not specified, all available stations will be selected.  Example: 1.1.sta001,1.1.wlan0,...")
+                        help="If specified, these stations will be used.  If not specified, all available stations will be selected.  Example: 1.1.sta001,1.1.wlan0,....\n"
+                            "Can also be used to specify custon names for the stations being created by --create_stations param")
     parser.add_argument("-cs", "--create_stations", default=False, action='store_true',
                         help="""create stations in lanforge (by default: False)
                         If specifed, either mention --num_stations or --stations to create stations in lanforge. If both are specified, --stations will be used to create stations
                         Also mention --radio, --ssid, --security and --password to create stations with these parameters""")
     parser.add_argument("-radio", "--radio", default="wiphy0",
-                        help="create stations in lanforge at this radio (by default: wiphy0)")
+                        help="create stations in lanforge at this radio (by default: wiphy0)")    #only one radio? or multiple radios possible?
     parser.add_argument("-ssid", "--ssid", default="",
-                        help="ssid name")
+                        help="ssid of the network to which stations should connect to. Required if --create_stations is specified")
     parser.add_argument("-security", "--security", default="open",
                         help="ssid Security type. If not open, then mention --password to create stations with this security type and password")
     parser.add_argument("-paswd", "--paswd", "-passwd", "--passwd", "--password", "--key", dest="paswd", default="[BLANK]",
@@ -501,6 +525,7 @@ INCLUDE_IN_README:
         exit(0)
 
     cv_base_adjust_parser(args)
+    validate_args(args)
 
     # set up logger
     logger_config = lf_logger_config.lf_logger_config()


### PR DESCRIPTION
# Documentation Update for WCT, DPT & CSTA Scripts

## Changes

### 1. `lfcli_base.py`
- Added aliases for a few parameters.
- Ensured correct usage of optional and required parameters.
- Ensured common parameter references across all three scripts using `dest`.
- Updated parameter help descriptions.

#### `create_base_parser()` updates
1. `--mgr`
   - Added aliases: `--m` (from `cv_test_manager.py`), `--lanforge_ip` (suggested)
   - Set `dest="mgr"`

2. `--mgr_port`
   - Added aliases: `--port`, `--o` (from `cv_test_manager.py`), `--lanforge_port` (suggested)
   - Set `dest="port"`
   - Updated help (used from `cv_test_manager.py`)

#### `create_basic_argparse()` updates
1. `--mgr`
   - Added alias: `--lanforge_ip` (suggested)
   - Set `dest="mgr"`

2. `--port`
   - Added alias: `--lanforge_port` (suggested)
   - Set `dest="port"`

3. `--upstream_port`
   - Added alias: `--upstream` (from `lf_wifi_capacity_test.py`)

4. `--debug`
   - Removed alias `-d` as it was used for `--duration` in `lf_wifi_capacity_test.py`

5. `--radio`
   - Added default value
   - Updated help (used from `lf_wifi_capacity_test.py`)

6. `--password`
   - Added alias: `--paswd` (from `lf_wifi_capacity_test.py`)

7. Moved `--radio`, `--security`, and `--password` from **required** to **optional** parameters since they already have default values. Required parameters should only contain arguments without default values.

---

### 2. `LFUtils.py`
- Fixed a minor bug that could cause timeouts.

#### Changes
- The `sec_elapsed` variable was not incrementing inside the loop, while an `if` condition depended on it.
- Updated the loop to use `sec_elapsed` as the loop variable itself.

---

### 3. `cv_test_manager.py`
- Added parameter aliases.
- Ensured common parameter references using `dest`.
- Updated the help section.
- Added default values where required.
- Fixed a KPI pull report bug that logged an error even when the report was pulled successfully.

#### Parameter changes
1. `--mgr`
   - Added aliases: `--lfmgr` (from `lfcli_base.py`), `--lanforge_ip`

2. `--port`
   - Added aliases: `--mgr_port` (from `lfcli_base.py`), `--lanforge_port`

3. `--pull_report`
   - Set `default=False` (from object creation)
   - Updated help to include dependency information

4. `--force`
   - Added `default=False` (from object creation)

5. `kpi_results_present()`
   - Updated the logic.
   - Previously, if `local_lf_report_dir` was not specified, it returned `False` and logged an error, even though KPI results were available in the current working directory.
   - Updated the location to use the current working directory when not specified by the user (could also be set as the default).

---

### 4. `create_station.py`
- Fixed minor issues in the example CLI commands.
- Updated parameter `dest` values to align with other scripts.
- Updated parameter help descriptions.
- Help now mentions parameter dependencies where applicable.

#### Example CLI updates
- The acceptable values for `initial_band_pref` are:
  - `2.4GHz`
  - `5GHz`
  - `6GHz`

  (Already mentioned in `choices`.)

#### Parameter changes
1. Changed `mgr_port` to `port` via `dest`, so it is referenced as `port` in the script.

2. `--start_id`
   - Updated help to be more descriptive.

3. `--radio_antenna`
   - Removed the incorrect default value `-1` from the help.
   - Obtained from the LANforge documentation.

4. `--country_code`
   - Updated documentation to be more descriptive.

5. Updated help to show dependency parameters for:
   - `--eap_method`
   - `--radius_passwd`
   - `--pk_passwd`
   - `--ca_cert`
   - `--private_key`
   - `--key_mgmt`
   - `--groupwise_cipher`

   (Obtained from `validate_args()`.)

6. `--passwd`
   - Updated reference to `paswd` to align with other scripts.

---

### 5. `lf_dataplane_test.py`
- Ensured common parameter references using `dest`.
- Added parameter aliases.
- Updated parameter help descriptions.

#### Parameter changes
1. Updated `--station` reference to `stations` using `dest` to align with other scripts.

2. Changed `traffic_types` to `traffic_type`.

3. `--upstream`
   - Added alias: `--upstream_port` (from `lfcli_base.py`)

4. `--lf_logger_config_json`
   - Updated help using the description from `lf_wifi_capacity_test.py`.

---

### 6. `lf_wifi_capacity_test.py`
- Added example CLI commands for various scenarios.
- Updated parameter references using `dest`.
- Added `validate_args()` to ensure dependent parameters are provided.
- Added parameter aliases.
- Updated help descriptions to show parameter dependencies.

#### Example scenarios added
1. Create stations:
   - Using number of stations
   - Using station names
   - With specified radio and network credentials

2. Run test with per-station upload/download rates.

3. Run test with batches per iteration.

4. Run test and pull reports to a custom directory.

5. Run test with custom upload/download rates.

#### Parameter changes
1. `--protocol`
   - Changed reference to `traffic_type` using `dest`
   - Added `traffic_types`

2. Added `validate_args()` to validate:
   - `--num_stations` or `--stations` with `--create_stations`
   - `--ssid` and `--security` with `--create_stations`
   - `--paswd` when security is not `open`

3. `--upstream`
   - Added alias: `--upstream_port`
   - Updated help

4. `--batch_size`
   - Updated help

5. `--loop_iter`
   - Updated help

6. `--protocol`
   - Added aliases from other scripts
   - Updated help

7. `--duration`
   - Updated help

8. `--verbosity`
   - Updated help

9. `--upload_rate`
   - Added aliases

10. `--stations`
    - Added alias: `--station`
    - Updated help

11. `--create_stations`
    - Updated help to show dependency parameters

12. `--ssid`, `--security`, `--password`
    - Updated help to show dependency parameters.