### PR TITLE
lf_interop_youtube.py: improve logs, add try except for api calls and add endpoint monitoring

### DIFF
--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -126,7 +126,6 @@ from datetime import datetime, timedelta
 from flask import Flask, request, jsonify
 from threading import Thread
 import traceback
-import threading
 from collections import Counter
 import re
 logger = logging.getLogger(__name__)
@@ -140,9 +139,6 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.
 
 
 # Import LANforge-related modules
-
-# Set up logging
-logger = logging.getLogger(__name__)
 
 # Import LF logger configuration module
 lf_logger_config = importlib.import_module("py-scripts.lf_logger_config")
@@ -251,8 +247,8 @@ class Youtube(Realm):
         self.generic_endps_profile.name_prefix = "yt"
         self.endpoint_last_status = {}
         self.Devices = None
-        self.start_time = ""
-        self.stop_time = ""
+        self.start_time = None
+        self.stop_time = None
         self.do_webUI = do_webUI
         self.ui_report_dir = ui_report_dir
         self.devices = base_RealDevice(manager_ip=self.host, selected_bands=[])
@@ -264,8 +260,7 @@ class Youtube(Realm):
         self.ssid = ssid
         self.security = security
         self.band = band
-        self.start_time = None,
-        self.est_end_time = None,
+        self.est_end_time = None
         self.all_stop = False
         self.keys = []
         self.hostname_os_combination = None
@@ -934,7 +929,7 @@ class Youtube(Realm):
             response.status_code = 200
 
             # Start shutdown in a separate thread
-            shutdown_thread = threading.Thread(target=self.shutdown)
+            shutdown_thread = Thread(target=self.shutdown)
             shutdown_thread.start()
 
             return response

--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -249,6 +249,7 @@ class Youtube(Realm):
         self.generic_endps_profile = self.new_generic_endp_profile()
         self.generic_endps_profile.type = 'youtube'
         self.generic_endps_profile.name_prefix = "yt"
+        self.endpoint_last_status = {}
         self.Devices = None
         self.start_time = ""
         self.stop_time = ""
@@ -1696,6 +1697,74 @@ class Youtube(Realm):
 
         return response
 
+    def monitor_endpoint_status_changes(self, wait_time=40, poll_interval=5):
+        """
+        Checks the current status of every generic endpoint and, only the
+        first time an endpoint's status changes, logs a message and appends
+        a row (timestamp, endpoint_name, status) to
+        endpoint_status_changes.csv. Repeated polls of an unchanged status
+        are not logged or written again.
+
+        If every created endpoint is missing from the response, retries
+        every poll_interval seconds for up to wait_time seconds. Aborts the
+        test if still none of the created endpoints have responded once
+        wait_time has elapsed.
+        """
+        current_path = self.ui_report_dir if self.do_webUI else os.path.dirname(os.path.abspath(__file__))
+        csv_file = os.path.join(current_path, "endpoint_status_changes.csv")
+        if csv_file not in self.devices_list:
+            self.devices_list.append(csv_file)
+        created_endp = self.generic_endps_profile.created_endp
+
+        start_time = time.time()
+        endpoint_data = {}
+        while True:
+            for gen_endp in created_endp:
+                generic_endpoint = self.json_get(f"/generic/{gen_endp}")
+                if generic_endpoint and "endpoint" in generic_endpoint:
+                    endpoint_data[gen_endp] = generic_endpoint
+
+            if endpoint_data or (time.time() - start_time) >= wait_time:
+                break
+
+            logger.warning(
+                "No data received for any of the created endpoints; retrying..."
+            )
+            time.sleep(poll_interval)
+
+        if not endpoint_data:
+            logger.error(
+                f"No data received for any of the created endpoints after waiting "
+                f"{wait_time} seconds. Aborting test."
+            )
+            exit(1)
+
+        for gen_endp, generic_endpoint in endpoint_data.items():
+            current_status = generic_endpoint["endpoint"].get("status", "")
+            previous_status = self.endpoint_last_status.get(gen_endp)
+
+            if current_status == previous_status:
+                continue
+
+            logger.info(
+                f"Endpoint {gen_endp} status changed to: {current_status}"
+            )
+
+            file_exists = os.path.isfile(csv_file) and os.path.getsize(csv_file) > 0
+            with open(csv_file, mode="a", newline="") as f:
+                writer = csv.writer(f)
+                if not file_exists:
+                    writer.writerow(["timestamp", "endpoint_name", "status"])
+                writer.writerow(
+                    [
+                        datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        gen_endp,
+                        current_status,
+                    ]
+                )
+
+            self.endpoint_last_status[gen_endp] = current_status
+
     def check_gen_cx(self):
         try:
 
@@ -2004,7 +2073,7 @@ class Youtube(Realm):
         self.wifi_interface_list = []
 
         # Step 3: Retrieve port information
-        response_port = self.json_get("/port/all")
+        response_port = self.json_get_with_retry("/port/all")
         try:
             interfaces_list = response_port.get('interfaces', [])
 
@@ -2067,6 +2136,7 @@ class Youtube(Realm):
                             self.start_generic()
                             end_time = datetime.now() + timedelta(minutes=self.duration)
 
+                        self.monitor_endpoint_status_changes()
                         time.sleep(5)
 
                     self.generic_endps_profile.stop_cx()
@@ -2085,6 +2155,7 @@ class Youtube(Realm):
                         self.start_generic()
                         end_time = datetime.now() + timedelta(minutes=self.duration)
 
+                    self.monitor_endpoint_status_changes()
                     time.sleep(5)
 
                 self.generic_endps_profile.stop_cx()
@@ -2980,6 +3051,7 @@ NOTES:
                 end_time = datetime.now() + timedelta(minutes=duration)
 
                 while datetime.now() < end_time or not youtube.check_gen_cx():
+                    youtube.monitor_endpoint_status_changes()
                     time.sleep(1)
 
                 youtube.generic_endps_profile.stop_cx()

--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -2588,6 +2588,7 @@ class Youtube(Realm):
 
 
 def main():
+    iot_summary = None
     try:
         help_summary = '''\
         Youtube streaming automation
@@ -3052,7 +3053,6 @@ NOTES:
                 youtube.generic_endps_profile.stop_cx()
                 logging.info("Duration ended")
 
-            iot_summary = None
             if args.iot_test and args.iot_testname:
                 base = os.path.join("results", args.iot_testname)
                 p = os.path.join(base, "iot_summary.json")

--- a/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
+++ b/py-scripts/real_application_tests/youtube/lf_interop_youtube.py
@@ -522,7 +522,7 @@ class Youtube(Realm):
         if real_sta_list is None:
             self.real_sta_list, _, _ = real_devices.query_user()
         else:
-            interface_data = self.json_get("/port/all")
+            interface_data = self.json_get_with_retry("/port/all")
             interfaces = interface_data["interfaces"]
             final_device_list = []  # Initialize the list
 
@@ -1674,6 +1674,28 @@ class Youtube(Realm):
         self.report.write_html()
         self.report.write_pdf()
 
+    def json_get_with_retry(self, url, wait_time=40, poll_interval=5):
+        """
+        Calls self.json_get(url), retrying every poll_interval seconds for up
+        to wait_time seconds if LANforge returns no response. Aborts the test
+        if it still hasn't responded once wait_time has elapsed.
+        """
+        start_time = time.time()
+        response = self.json_get(url)
+        while response is None and (time.time() - start_time) < wait_time:
+            logger.warning(f"GET {url} returned no response from LANforge; retrying...")
+            time.sleep(poll_interval)
+            response = self.json_get(url)
+
+        if response is None:
+            logger.error(
+                f"GET {url} returned no response from LANforge after waiting "
+                f"{wait_time} seconds. Aborting test."
+            )
+            exit(1)
+
+        return response
+
     def check_gen_cx(self):
         try:
 
@@ -1719,9 +1741,21 @@ class Youtube(Realm):
         if upstream_port.count('.') != 3:
             target_port_list = self.name_to_eid(upstream_port)
             shelf, resource, port, _ = target_port_list
+            response = self.json_get_with_retry(f'/port/{shelf}/{resource}/{port}?fields=ip')
             try:
-                target_port_ip = self.json_get(f'/port/{shelf}/{resource}/{port}?fields=ip')['interface']['ip']
+                target_port_ip = response['interface']['ip']
                 upstream_port = target_port_ip
+            except KeyError as e:
+                logger.error(
+                    "/port/%s/%s/%s/?fields=ip response is not in the expected format, missing key %s. "
+                    "Data received:\n%s",
+                    shelf,
+                    resource,
+                    port,
+                    e,
+                    json.dumps(response, indent=2, default=str),
+                )
+                exit(1)
             except Exception as e:
                 logging.warning(f'Could not resolve IP for port {upstream_port}: {e}. Proceeding with the given upstream_port {upstream_port}.')
                 logging.warning(f'The upstream port is not an ethernet port. Proceeding with the given upstream_port {upstream_port}.')
@@ -1831,37 +1865,52 @@ class Youtube(Realm):
         Returns:
             None
         """
-        interop_data = self.json_get('/adb')
-        interop_mobile_data = interop_data.get('devices', {})
+        interop_data = self.json_get_with_retry('/adb')
+        try:
+            interop_mobile_data = interop_data.get('devices', {})
 
-        if isinstance(interop_mobile_data, dict):
-            for user in self.user_list:
-                if user != '':
-                    if interop_mobile_data.get('user-name') == user:
+            if isinstance(interop_mobile_data, dict):
+                for user in self.user_list:
+                    if user != '':
+                        if interop_mobile_data.get('user-name') == user:
 
-                        serial = interop_mobile_data.get('name', '')
-                        resource = serial.split('.')[1]
-                        serial_no = serial.split('.')[2]
-                        self.serial_list.append(serial_no)
-                        lanforge_port = f"1.{resource}.eth0"
-                        self.lanforge_port_list.add(lanforge_port)
+                            serial = interop_mobile_data.get('name', '')
+                            resource = serial.split('.')[1]
+                            serial_no = serial.split('.')[2]
+                            self.serial_list.append(serial_no)
+                            lanforge_port = f"1.{resource}.eth0"
+                            self.lanforge_port_list.add(lanforge_port)
 
-        else:
-            for user in self.user_list:
-                if user != '':
-                    for mobile_device in interop_mobile_data:
-                        for serial, device_data in mobile_device.items():
-                            if device_data.get('user-name') == user:
-                                resource = serial.split('.')[1]
-                                serial_no = serial.split('.')[2]
-                                self.serial_list.append(serial_no)
-                                lanforge_port = f"1.{resource}.eth0"
-                                self.lanforge_port_list.add(lanforge_port)
-                                break
+            else:
+                for user in self.user_list:
+                    if user != '':
+                        for mobile_device in interop_mobile_data:
+                            for serial, device_data in mobile_device.items():
+                                if device_data.get('user-name') == user:
+                                    resource = serial.split('.')[1]
+                                    serial_no = serial.split('.')[2]
+                                    self.serial_list.append(serial_no)
+                                    lanforge_port = f"1.{resource}.eth0"
+                                    self.lanforge_port_list.add(lanforge_port)
+                                    break
 
-        self.lanforge_port_list = list(self.lanforge_port_list)
-        self.lanforge_os_type = ["Linux"] * len(self.lanforge_port_list)
-        self.serial_list_str = ','.join(self.serial_list)
+            self.lanforge_port_list = list(self.lanforge_port_list)
+            self.lanforge_os_type = ["Linux"] * len(self.lanforge_port_list)
+            self.serial_list_str = ','.join(self.serial_list)
+        except KeyError as e:
+            logger.error(
+                "/adb response is not in the expected format, missing key %s. "
+                "Data received:\n%s",
+                e,
+                json.dumps(interop_data, indent=2, default=str),
+            )
+            exit(1)
+        except Exception as e:
+            logger.error(
+                f"Unexpected error while parsing /adb response: {e}",
+                exc_info=True,
+            )
+            exit(1)
 
     def get_device_data(self):
         """
@@ -1906,24 +1955,47 @@ class Youtube(Realm):
         self.user_list = []
 
         # Step 1: Retrieve information about all resources
-        response = self.json_get("/resource/all")
-        resource_data_list = response.get("resources", [])
+        response = self.json_get_with_retry("/resource/all")
+        try:
+            resource_data_list = response.get("resources", [])
 
-        # Step 2: Match user-specified resources with available resources in order.
-        for user_resource in user_resources:
-            for resource_entry in resource_data_list:
-                for resource_key, resource_values in resource_entry.items():
-                    if resource_key == user_resource:
-                        self.device_names.append(resource_values['hostname'])
-                        ports_list.append({
-                            'eid': resource_values['eid'],
-                            'ctrl-ip': resource_values['ctrl-ip']
-                        })
-                        self.user_list.append(resource_values['user'])
-                        break
+            # Step 2: Match user-specified resources with available resources in order.
+            for user_resource in user_resources:
+                for resource_entry in resource_data_list:
+                    for resource_key, resource_values in resource_entry.items():
+                        if resource_key == user_resource:
+                            self.device_names.append(resource_values['hostname'])
+                            ports_list.append({
+                                'eid': resource_values['eid'],
+                                'ctrl-ip': resource_values['ctrl-ip']
+                            })
+                            self.user_list.append(resource_values['user'])
+                            break
+                    else:
+                        continue
+                    break
                 else:
-                    continue
-                break
+                    logger.error(
+                        f"Resource {user_resource} not found in LANforge response. Aborting test."
+                    )
+                    logger.info(
+                        "LANforge resources fetched from /resource/all:\n%s",
+                        json.dumps(resource_data_list, indent=2, default=str),
+                    )
+                    exit(1)
+        except KeyError as e:
+            logger.error(
+                f"/resource/all response is not in the expected format, missing key {e}. "
+                "Data received:\n%s",
+                json.dumps(response, indent=2, default=str),
+            )
+            exit(1)
+        except Exception as e:
+            logger.error(
+                f"Unexpected error while parsing /resource/all response: {e}",
+                exc_info=True,
+            )
+            exit(1)
 
         self.mac_list = []
         self.rssi_list = []
@@ -1933,25 +2005,39 @@ class Youtube(Realm):
 
         # Step 3: Retrieve port information
         response_port = self.json_get("/port/all")
-        interfaces_list = response_port.get('interfaces', [])
+        try:
+            interfaces_list = response_port.get('interfaces', [])
 
-        # Step 4: Match ports associated with retrieved resources in the order of ports_list
-        for port_entry in ports_list:
-            expected_eid = port_entry['eid']
-            matched_ports = []
+            # Step 4: Match ports associated with retrieved resources in the order of ports_list
+            for port_entry in ports_list:
+                expected_eid = port_entry['eid']
+                matched_ports = []
 
-            for interface in interfaces_list:
-                for port, port_data in interface.items():
-                    if '.'.join(port.split('.')[:2]) == expected_eid:
-                        matched_ports.append((port, port_data))
+                for interface in interfaces_list:
+                    for port, port_data in interface.items():
+                        if '.'.join(port.split('.')[:2]) == expected_eid:
+                            matched_ports.append((port, port_data))
 
-            for port_name, port_data in matched_ports:
-                if port_data.get("parent dev") == 'wiphy0' and not port_data.get('down') and port_data.get('ip') != '0.0.0.0':
-                    self.mac_list.append(port_data.get("mac"))
-                    self.rssi_list.append(port_data.get("signal"))
-                    self.link_rate_list.append(port_data.get("rx-rate"))
-                    self.ssid_list.append(port_data.get("ssid"))
-                    self.wifi_interface_list.append(port_name.split('.')[2])
+                for port_name, port_data in matched_ports:
+                    if port_data.get("parent dev") == 'wiphy0' and not port_data.get('down') and port_data.get('ip') != '0.0.0.0':
+                        self.mac_list.append(port_data.get("mac"))
+                        self.rssi_list.append(port_data.get("signal"))
+                        self.link_rate_list.append(port_data.get("rx-rate"))
+                        self.ssid_list.append(port_data.get("ssid"))
+                        self.wifi_interface_list.append(port_name.split('.')[2])
+        except KeyError as e:
+            logger.error(
+                f"/port/all response is not in the expected format, missing key {e}. "
+                "Data received:\n%s",
+                json.dumps(response_port, indent=2, default=str),
+            )
+            exit(1)
+        except Exception as e:
+            logger.error(
+                f"Unexpected error while parsing /port/all response: {e}",
+                exc_info=True,
+            )
+            exit(1)
 
     def perform_robo_test(self):
         if self.do_webUI:


### PR DESCRIPTION
This PR introduces three main updates to make the YouTube automation script more stable and observable:

  • More Resilient API Calls: Added an automatic retry mechanism and better error handling (try-except for KeyErrors) when fetching data from the LANforge API. This prevents tests from suddenly
  failing due to temporary network hiccups or incomplete data.
  • Endpoint Status Monitoring: Added a new feature that continuously monitors all test endpoints and logs any status changes directly into a CSV file (endpoint_status_changes.csv) for easier
  tracking.
  • Code Cleanup: Fixed minor bugs by removing duplicate logger configurations and redundant thread imports